### PR TITLE
feat: create sqs_configure module to update sqs policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,3 +28,11 @@ module "api_gateway" {
   sqs_queue_name = module.sqs.sqs_queue_name
   sqs_queue_arn  = module.sqs.sqs_queue_arn
 }
+
+module "sqs_configure" {
+  source          = "./modules/sqs_configure"
+  api_gateway_arn = module.api_gateway.api_gateway_execution_arn
+  sqs_queue_arn   = module.sqs.sqs_queue_arn
+  sqs_queue_name  = module.sqs.sqs_queue_name
+  sqs_queue_id    = module.sqs.sqs_queue_id
+}

--- a/modules/sqs_configure/main.tf
+++ b/modules/sqs_configure/main.tf
@@ -1,0 +1,22 @@
+resource "aws_sqs_queue_policy" "queue_policy" {
+  queue_url = var.sqs_queue_id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "apigateway.amazonaws.com"
+      }
+      Action = "SQS:SendMessage"
+      Resource = var.sqs_queue_arn
+      Condition = {
+        StringEquals = {
+          "AWS:SourceArn" = var.api_gateway_arn
+        }
+      }
+    }]
+  })
+}
+
+# add lambda config after lambda is provisioned

--- a/modules/sqs_configure/variables.tf
+++ b/modules/sqs_configure/variables.tf
@@ -1,0 +1,19 @@
+variable "api_gateway_arn" {
+  description = "The ARN of the API Gateway."
+  type        = string
+}
+
+variable "sqs_queue_arn" {
+  description = "The ARN of the SQS queue."
+  type        = string
+}
+
+variable "sqs_queue_name" {
+  description = "The name of the SQS queue."
+  type        = string
+}
+
+variable "sqs_queue_id" {
+  description = "The URL of the SQS queue."
+  type        = string
+}


### PR DESCRIPTION
The SQS queue needs to be created first, to allow API Gateway setup. This sqs_configure module adds an sqs policy, allowing API Gateway to send messages. Later, this module will also be used to update Lambda permission after the Lambda function is provisioned. 